### PR TITLE
More elements to ignore by the gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 build
 /outputs
 /checkpoints
+__pycache__
+/dist
+/src


### PR DESCRIPTION
Context:
When developing using this repository, some files were tracked by git while not being necessary. This PR aims at adding more unnecessary files to the gitignore

Changes:
add /src/, /dist and __pycache__ to gitignore