### PR TITLE
Using CPU as the default device in the Discretizer to avoid wasting memory in the rank 0 GPU

### DIFF
--- a/sgm/modules/diffusionmodules/discretizer.py
+++ b/sgm/modules/diffusionmodules/discretizer.py
@@ -7,7 +7,7 @@ from ...modules.diffusionmodules.util import make_beta_schedule
 
 
 class Discretization:
-    def __call__(self, n, do_append_zero=True, device="cuda", flip=False):
+    def __call__(self, n, do_append_zero=True, device="cpu", flip=False):
         sigmas = self.get_sigmas(n, device)
         sigmas = append_zero(sigmas) if do_append_zero else sigmas
         return sigmas if not flip else torch.flip(sigmas, (0,))


### PR DESCRIPTION
Using CPU as the default device. 

The models are initialized way before the `init_process_group()` is invoked. The Discretizer is placed in the GPU at initialization, and at this stage, it is always the first GPU in the node. Therefore some CUDA buffers are initialized and not liberated when the model is placed in the right place. Initializing the `Discretizer` in the CPU fixes the problem.