### PR TITLE
[Don't merge] PR to show that `diffusers` and SGM gives 1-to-1 the same result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 build
 /outputs
 /checkpoints
+__pycache__

--- a/scripts/demo/sampling.py
+++ b/scripts/demo/sampling.py
@@ -126,9 +126,10 @@ def run_txt2img(
         use_identity_guider=not version_dict["is_guided"]
     )
 
-    num_samples = num_rows * num_cols
+    # num_samples = num_rows * num_cols
+    num_samples = 1
 
-    if st.button("Sample"):
+    if True:
         st.write(f"**Model I:** {version}")
         out = do_sample(
             state["model"],
@@ -307,6 +308,7 @@ if __name__ == "__main__":
         )
     else:
         raise ValueError(f"unknown mode {mode}")
+
     if isinstance(out, (tuple, list)):
         samples, samples_z = out
     else:

--- a/scripts/demo/streamlit_helpers.py
+++ b/scripts/demo/streamlit_helpers.py
@@ -13,6 +13,7 @@ from torch import autocast
 from torchvision import transforms
 from torchvision.utils import make_grid
 from safetensors.torch import load_file as load_safetensors
+from pytorch_lightning import seed_everything
 
 from sgm.modules.diffusionmodules.sampling import (
     EulerEDMSampler,
@@ -206,6 +207,7 @@ def init_save_locally(_dir, init_value: bool = False):
     else:
         save_path = None
 
+    return True, "/home/patrick/images/sgm_test"
     return save_locally, save_path
 
 
@@ -513,7 +515,8 @@ def do_sample(
                     additional_model_inputs[k] = batch[k]
 
                 shape = (math.prod(num_samples), C, H // F, W // F)
-                randn = torch.randn(shape).to("cuda")
+                seed_everything(0)
+                randn = torch.randn(shape, device="cuda")
 
                 def denoiser(input, sigma, c):
                     return model.denoiser(


### PR DESCRIPTION
This PR was opened only to show that the default settings of SGM gives 1-to-1 the same results as the branch `sd_xl` (soon in "main"): https://github.com/huggingface/diffusers/pull/3859

You can verify this as follows:
```
git clone https://github.com/patrickvonplaten/generative-models.git
git checkout same_result_diff
```

Then make sure to add the SD-XL checkpoint to the `checkpoints` folder under `"./generative-models/checkpoints/sd_xl_base_0.9.safetensors"`. Then:

```
cd generative-models && python scripts/demo/sampling.py
```

This should generate an image that looks more or less like the following (results might vary depending on the GPU). The following image was created on a RTX4090:
 
![000000000](https://github.com/Stability-AI/generative-models/assets/23423619/86b593a2-5f6a-41b2-a6b1-c9ead29f0973)

Now you should get 1-to-1 the same result with `diffusers`. Simply do:

```
pip install git+https://github.com/huggingface/diffusers@sd_xl
```

and then run:

```py
#!/usr/bin/env python3
from diffusers import DiffusionPipeline
from pytorch_lightning import seed_everything
import torch

pipe = DiffusionPipeline.from_pretrained("stabilityai/stable-diffusion-xl-base-0.9", torch_dtype=torch.float16, variant="fp16", use_safetensors=True)
pipe.to("cuda")

prompt = "Astronaut in a jungle, cold color palette, muted colors, detailed, 8k"
seed_everything(0)
image = pipe(prompt=prompt).images[0]
image.save("/path/to/save")
```

which should give an image of the following:

![aaa (1)](https://github.com/Stability-AI/generative-models/assets/23423619/f1067a9a-79e0-4e2e-b517-39f1db6cf41d)

Note that when downloading the images you can see that they are not **100%** identical but for the human eye one cannot make a difference.