### PR TITLE
Fix `samples_z` undefined

### DIFF
--- a/scripts/demo/sampling.py
+++ b/scripts/demo/sampling.py
@@ -311,8 +311,9 @@ if __name__ == "__main__":
         samples, samples_z = out
     else:
         samples = out
+        samples_z = None
 
-    if add_pipeline:
+    if add_pipeline and samples_z is not None:
         st.write("**Running Refinement Stage**")
         samples = apply_refiner(
             samples_z,


### PR DESCRIPTION
This fixes the `NameError: name 'samples_z' is not defined` error, when the script tries to refine non-existent samples