### PR TITLE
improve test_inference.py

### DIFF
--- a/tests/inference/test_inference.py
+++ b/tests/inference/test_inference.py
@@ -1,7 +1,6 @@
 import numpy
 from PIL import Image
 import pytest
-from pytest import fixture
 import torch
 from typing import Tuple
 
@@ -17,27 +16,29 @@ import sgm.inference.helpers as helpers
 
 @pytest.mark.inference
 class TestInference:
-    @fixture(scope="class", params=model_specs.keys())
-    def pipeline(self, request) -> SamplingPipeline:
-        pipeline = SamplingPipeline(request.param)
-        yield pipeline
-        del pipeline
-        torch.cuda.empty_cache()
+    @classmethod
+    def setup_class(cls):
+        cls.pipeline_objects = {}
+        cls.sdxl_pipelines_objects = {}
+        for model_name in model_specs.keys():
+            cls.pipeline_objects[model_name] = SamplingPipeline(model_name)
 
-    @fixture(
-        scope="class",
-        params=[
+        for arch_pair in [
             [ModelArchitecture.SDXL_V1_BASE, ModelArchitecture.SDXL_V1_REFINER],
             [ModelArchitecture.SDXL_V0_9_BASE, ModelArchitecture.SDXL_V0_9_REFINER],
-        ],
-        ids=["SDXL_V1", "SDXL_V0_9"],
-    )
-    def sdxl_pipelines(self, request) -> Tuple[SamplingPipeline, SamplingPipeline]:
-        base_pipeline = SamplingPipeline(request.param[0])
-        refiner_pipeline = SamplingPipeline(request.param[1])
-        yield base_pipeline, refiner_pipeline
-        del base_pipeline
-        del refiner_pipeline
+        ]:
+            cls.sdxl_pipelines_objects[tuple(arch_pair)] = (
+                SamplingPipeline(arch_pair[0]),
+                SamplingPipeline(arch_pair[1]),
+            )
+
+    @classmethod
+    def teardown_class(cls):
+        for pipeline in cls.pipeline_objects.values():
+            del pipeline
+        for base_pipeline, refiner_pipeline in cls.sdxl_pipelines_objects.values():
+            del base_pipeline
+            del refiner_pipeline
         torch.cuda.empty_cache()
 
     def create_init_image(self, h, w):
@@ -46,18 +47,19 @@ class TestInference:
         return helpers.get_input_image_tensor(image)
 
     @pytest.mark.parametrize("sampler_enum", Sampler)
-    def test_txt2img(self, pipeline: SamplingPipeline, sampler_enum):
+    def test_txt2img(self, sampler_enum):
+        pipeline = self.pipeline_objects[sampler_enum.value]
         output = pipeline.text_to_image(
             params=SamplingParams(sampler=sampler_enum.value, steps=10),
             prompt="A professional photograph of an astronaut riding a pig",
             negative_prompt="",
             samples=1,
         )
-
         assert output is not None
 
     @pytest.mark.parametrize("sampler_enum", Sampler)
-    def test_img2img(self, pipeline: SamplingPipeline, sampler_enum):
+    def test_img2img(self, sampler_enum):
+        pipeline = self.pipeline_objects[sampler_enum.value]
         output = pipeline.image_to_image(
             params=SamplingParams(sampler=sampler_enum.value, steps=10),
             image=self.create_init_image(pipeline.specs.height, pipeline.specs.width),
@@ -71,13 +73,10 @@ class TestInference:
     @pytest.mark.parametrize(
         "use_init_image", [True, False], ids=["img2img", "txt2img"]
     )
-    def test_sdxl_with_refiner(
-        self,
-        sdxl_pipelines: Tuple[SamplingPipeline, SamplingPipeline],
-        sampler_enum,
-        use_init_image,
-    ):
-        base_pipeline, refiner_pipeline = sdxl_pipelines
+    def test_sdxl_with_refiner(self, sampler_enum, use_init_image):
+        base_pipeline, refiner_pipeline = self.sdxl_pipelines_objects[
+            (ModelArchitecture(base_pipeline.specs.architecture), ModelArchitecture(refiner_pipeline.specs.architecture))
+        ]
         if use_init_image:
             output = base_pipeline.image_to_image(
                 params=SamplingParams(sampler=sampler_enum.value, steps=10),


### PR DESCRIPTION
I guess, we can move the creation of `SamplingPipeline` objects and clearing the CUDA cache outside the test fixtures and execute them only once before and after the entire test class. This way, we reduce the overhead of object creation and deletion for each test case. Is something like this right?