### PR TITLE
fix EDMDiscretization sigma_min for correct sampling noise scheduling

### DIFF
--- a/sgm/modules/diffusionmodules/discretizer.py
+++ b/sgm/modules/diffusionmodules/discretizer.py
@@ -26,7 +26,7 @@ class Discretization:
 
 
 class EDMDiscretization(Discretization):
-    def __init__(self, sigma_min=0.02, sigma_max=80.0, rho=7.0):
+    def __init__(self, sigma_min=0.002, sigma_max=80.0, rho=7.0):
         self.sigma_min = sigma_min
         self.sigma_max = sigma_max
         self.rho = rho


### PR DESCRIPTION
I found a mistake in implementing "Elucidating the Design Space of Diffusion-Based Generative Models" noise scheduling.
In the EDMDiscretization you use `sigma_min=0.02`, but the value used in the original paper is 0.002.

This fix may influence the final quality of the sampling process.

Vital that you DO NOT need to retrain models because of this fix. The EDMSampling contains correct sampling of sigmas during training.
![image](https://github.com/Stability-AI/generative-models/assets/1451797/2b437c64-6675-45c5-94fd-e03e466f75c2)
