### PR TITLE
Replace remaining `print()` calls in library with logging calls

### DIFF
--- a/sgm/inference/helpers.py
+++ b/sgm/inference/helpers.py
@@ -1,3 +1,4 @@
+import logging
 import math
 import os
 from typing import List, Optional, Union
@@ -11,6 +12,8 @@ from PIL import Image
 from torch import autocast
 
 from sgm.util import append_dims
+
+logpy = logging.getLogger(__name__)
 
 
 class WatermarkEmbedder:
@@ -229,7 +232,7 @@ def get_batch(keys, value_dict, N: Union[List, ListConfig], device="cuda"):
 
 def get_input_image_tensor(image: Image.Image, device="cuda"):
     w, h = image.size
-    print(f"loaded input image of size ({w}, {h})")
+    logpy.info(f"loaded input image of size ({w}, {h})")
     width, height = map(
         lambda x: x - x % 64, (w, h)
     )  # resize to integer multiple of 64

--- a/sgm/lr_scheduler.py
+++ b/sgm/lr_scheduler.py
@@ -1,4 +1,8 @@
+import logging
+
 import numpy as np
+
+logpy = logging.getLogger(__name__)
 
 
 class LambdaWarmUpCosineScheduler:
@@ -26,7 +30,7 @@ class LambdaWarmUpCosineScheduler:
     def schedule(self, n, **kwargs):
         if self.verbosity_interval > 0:
             if n % self.verbosity_interval == 0:
-                print(f"current step: {n}, recent lr-multiplier: {self.last_lr}")
+                logpy.info(f"current step: {n}, recent lr-multiplier: {self.last_lr}")
         if n < self.lr_warm_up_steps:
             lr = (
                 self.lr_max - self.lr_start
@@ -85,9 +89,9 @@ class LambdaWarmUpCosineScheduler2:
         n = n - self.cum_cycles[cycle]
         if self.verbosity_interval > 0:
             if n % self.verbosity_interval == 0:
-                print(
+                logpy.info(
                     f"current step: {n}, recent lr-multiplier: {self.last_f}, "
-                    f"current cycle {cycle}"
+                    f"current cycle {cycle}",
                 )
         if n < self.lr_warm_up_steps[cycle]:
             f = (self.f_max[cycle] - self.f_start[cycle]) / self.lr_warm_up_steps[
@@ -116,9 +120,9 @@ class LambdaLinearScheduler(LambdaWarmUpCosineScheduler2):
         n = n - self.cum_cycles[cycle]
         if self.verbosity_interval > 0:
             if n % self.verbosity_interval == 0:
-                print(
+                logpy.info(
                     f"current step: {n}, recent lr-multiplier: {self.last_f}, "
-                    f"current cycle {cycle}"
+                    f"current cycle {cycle}",
                 )
 
         if n < self.lr_warm_up_steps[cycle]:

--- a/sgm/modules/autoencoding/losses/discriminator_loss.py
+++ b/sgm/modules/autoencoding/losses/discriminator_loss.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 import numpy as np
@@ -12,6 +13,8 @@ from ....util import default, instantiate_from_config
 from ..lpips.loss.lpips import LPIPS
 from ..lpips.model.model import weights_init
 from ..lpips.vqperceptual import hinge_d_loss, vanilla_d_loss
+
+logpy = logging.getLogger(__name__)
 
 
 class GeneralLPIPSWithDiscriminator(nn.Module):
@@ -35,7 +38,7 @@ class GeneralLPIPSWithDiscriminator(nn.Module):
         super().__init__()
         self.dims = dims
         if self.dims > 2:
-            print(
+            logpy.info(
                 f"running with dims={dims}. This means that for perceptual loss "
                 f"calculation, the LPIPS loss will be applied to each frame "
                 f"independently."

--- a/sgm/modules/autoencoding/lpips/loss/lpips.py
+++ b/sgm/modules/autoencoding/lpips/loss/lpips.py
@@ -1,5 +1,5 @@
 """Stripped version of https://github.com/richzhang/PerceptualSimilarity/tree/master/models"""
-
+import logging
 from collections import namedtuple
 
 import torch
@@ -7,6 +7,8 @@ import torch.nn as nn
 from torchvision import models
 
 from ..util import get_ckpt_path
+
+logpy = logging.getLogger(__name__)
 
 
 class LPIPS(nn.Module):
@@ -30,7 +32,7 @@ class LPIPS(nn.Module):
         self.load_state_dict(
             torch.load(ckpt, map_location=torch.device("cpu")), strict=False
         )
-        print("loaded pretrained LPIPS loss from {}".format(ckpt))
+        logpy.info(f"loaded pretrained LPIPS loss from {ckpt}")
 
     @classmethod
     def from_pretrained(cls, name="vgg_lpips"):

--- a/sgm/modules/autoencoding/lpips/util.py
+++ b/sgm/modules/autoencoding/lpips/util.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 import os
 
 import requests
@@ -11,6 +12,8 @@ URL_MAP = {"vgg_lpips": "https://heibox.uni-heidelberg.de/f/607503859c864bc1b30b
 CKPT_MAP = {"vgg_lpips": "vgg.pth"}
 
 MD5_MAP = {"vgg_lpips": "d507d7349b931f0638a25a48a722f98a"}
+
+logpy = logging.getLogger(__name__)
 
 
 def download(url, local_path, chunk_size=1024):
@@ -35,7 +38,7 @@ def get_ckpt_path(name, root, check=False):
     assert name in URL_MAP
     path = os.path.join(root, CKPT_MAP[name])
     if not os.path.exists(path) or (check and not md5_hash(path) == MD5_MAP[name]):
-        print("Downloading {} model from {} to {}".format(name, URL_MAP[name], path))
+        logpy.info(f"Downloading {name} model from {URL_MAP[name]} to {path}")
         download(URL_MAP[name], path)
         md5 = md5_hash(path)
         assert md5 == MD5_MAP[name], md5

--- a/sgm/modules/autoencoding/temporal_ae.py
+++ b/sgm/modules/autoencoding/temporal_ae.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Callable, Iterable, Union
 
 import torch
@@ -13,6 +14,8 @@ from sgm.modules.diffusionmodules.model import (
 from sgm.modules.diffusionmodules.openaimodel import ResBlock, timestep_embedding
 from sgm.modules.video_attention import VideoTransformerBlock
 from sgm.util import partialclass
+
+logpy = logging.getLogger(__name__)
 
 
 class VideoResBlock(ResnetBlock):
@@ -258,13 +261,12 @@ def make_time_attn(
         "vanilla",
         "vanilla-xformers",
     ], f"attn_type {attn_type} not supported for spatio-temporal attention"
-    print(
-        f"making spatial and temporal attention of type '{attn_type}' with {in_channels} in_channels"
-    )
+    logpy.info(f"making spatial and temporal attention of type '{attn_type}' with {in_channels} in_channels")
     if not XFORMERS_IS_AVAILABLE and attn_type == "vanilla-xformers":
-        print(
+        logpy.warning(
             f"Attention mode '{attn_type}' is not available. Falling back to vanilla attention. "
-            f"This is not a problem in Pytorch >= 2.0. FYI, you are running with PyTorch version {torch.__version__}"
+            f"This is not a problem in Pytorch >= 2.0. "
+            f"FYI, you are running with PyTorch version {torch.__version__}"
         )
         attn_type = "vanilla"
 
@@ -274,7 +276,7 @@ def make_time_attn(
             VideoBlock, in_channels, alpha=alpha, merge_strategy=merge_strategy
         )
     elif attn_type == "vanilla-xformers":
-        print(f"building MemoryEfficientAttnBlock with {in_channels} in_channels...")
+        logpy.info(f"building MemoryEfficientAttnBlock with {in_channels} in_channels...")
         return partialclass(
             MemoryEfficientVideoBlock,
             in_channels,

--- a/sgm/modules/diffusionmodules/sampling.py
+++ b/sgm/modules/diffusionmodules/sampling.py
@@ -1,8 +1,7 @@
 """
     Partially ported from https://github.com/crowsonkb/k-diffusion/blob/master/k_diffusion/sampling.py
 """
-
-
+import logging
 from typing import Dict, Union
 
 import torch
@@ -16,6 +15,8 @@ from ...modules.diffusionmodules.sampling_utils import (get_ancestral_step,
 from ...util import append_dims, default, instantiate_from_config
 
 DEFAULT_GUIDER = {"target": "sgm.modules.diffusionmodules.guiders.IdentityGuider"}
+
+logpy = logging.getLogger(__name__)
 
 
 class BaseDiffusionSampler:
@@ -60,9 +61,9 @@ class BaseDiffusionSampler:
         sigma_generator = range(num_sigmas - 1)
         if self.verbose:
             print("#" * 30, " Sampling setting ", "#" * 30)
-            print(f"Sampler: {self.__class__.__name__}")
-            print(f"Discretization: {self.discretization.__class__.__name__}")
-            print(f"Guider: {self.guider.__class__.__name__}")
+            logpy.info(f"Sampler: {self.__class__.__name__}")
+            logpy.info(f"Discretization: {self.discretization.__class__.__name__}")
+            logpy.info(f"Guider: {self.guider.__class__.__name__}")
             sigma_generator = tqdm(
                 sigma_generator,
                 total=num_sigmas,

--- a/sgm/modules/diffusionmodules/video_model.py
+++ b/sgm/modules/diffusionmodules/video_model.py
@@ -1,3 +1,4 @@
+import logging
 from functools import partial
 from typing import List, Optional, Union
 
@@ -7,6 +8,9 @@ from ...modules.diffusionmodules.openaimodel import *
 from ...modules.video_attention import SpatialVideoTransformer
 from ...util import default
 from .util import AlphaBlender
+
+
+logpy = logging.getLogger(__name__)
 
 
 class VideoResBlock(ResBlock):
@@ -159,7 +163,7 @@ class VideoUNet(nn.Module):
             if isinstance(self.num_classes, int):
                 self.label_emb = nn.Embedding(num_classes, time_embed_dim)
             elif self.num_classes == "continuous":
-                print("setting up linear c_adm embedding layer")
+                logpy.info("setting up linear c_adm embedding layer")
                 self.label_emb = nn.Linear(1, time_embed_dim)
             elif self.num_classes == "timestep":
                 self.label_emb = nn.Sequential(

--- a/sgm/modules/video_attention.py
+++ b/sgm/modules/video_attention.py
@@ -1,7 +1,10 @@
 import torch
+import logging
 
 from ..modules.attention import *
 from ..modules.diffusionmodules.util import AlphaBlender, linear, timestep_embedding
+
+logpy = logging.getLogger(__name__)
 
 
 class TimeMixSequential(nn.Sequential):
@@ -96,7 +99,7 @@ class VideoTransformerBlock(nn.Module):
 
         self.checkpoint = checkpoint
         if self.checkpoint:
-            print(f"{self.__class__.__name__} is using checkpointing")
+            logpy.info(f"{self.__class__.__name__} is using checkpointing")
 
     def forward(
         self, x: torch.Tensor, context: torch.Tensor = None, timesteps: int = None


### PR DESCRIPTION
Follows up on #42 and #77.

Follows the `logpy` naming introduced by @timudk in https://github.com/Stability-AI/generative-models/commit/059d8e9cd9c55aea1ef2ece39abf605efb8b7cc9.