### PR TITLE
CI: don't attempt CI with a requirements file that's no longer there

### DIFF
--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.10"]
-        requirements-file: ["pt2", "pt13"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -23,5 +22,5 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements/${{ matrix.requirements-file }}.txt
+          pip install -r requirements/pt2.txt
           pip install .


### PR DESCRIPTION
`requirements/pt13.txt` was deleted by @timudk in ed0997173f98eaf8f4edf7ba5fe8f15c6b877fd3, causing subsequent commits to fail CI since they attempt to use a file that's no longer there.