### PR TITLE
Fix initial noise standard deviation

### DIFF
--- a/sgm/modules/diffusionmodules/sampling.py
+++ b/sgm/modules/diffusionmodules/sampling.py
@@ -44,7 +44,7 @@ class BaseDiffusionSampler:
         )
         uc = default(uc, cond)
 
-        x *= torch.sqrt(1.0 + sigmas[0] ** 2.0)
+        x *= sigmas[0]
         num_sigmas = len(sigmas)
 
         s_in = x.new_ones([x.shape[0]])


### PR DESCRIPTION
`prepare_sampling_loop` in diffusionmodules/sampling.py currently initializes the initial noise with standard deviation `sqrt(1+sigma^2)`. However, according to the EDM paper [1], the initial noise standard deviation should just be sigma. (See line 2 of Algorithm 2 of "Elucidating the Design Space of Diffusion-Based Generative Models".) This pull request fixes the issue.

I tested the change using the code below:
```
import importlib
import numpy
import torch
import torchvision

import sgm
import sgm.inference.api as api

pipeline = api.SamplingPipeline(api.ModelArchitecture.SDXL_V1_BASE)

torch.manual_seed(1)
output = pipeline.text_to_image(
    params=api.SamplingParams(steps=10),
    prompt="A professional photograph of an astronaut riding a pig")
torchvision.utils.save_image(output[0], 'image.png')
```
Below are the results. Note that after the fix, there are several improvements:
- an extra leg is removed behind the pig's front left leg
- pig's right eye no longer unrealistically pops out of the pig's face
- better pig nose
- better pig tail
- back of astronaut helmet doesn't look as strange
- the patch on the right of the astronaut's shoulder is no longer blurry

This is the only test I bothered trying. More tests/checks may be warranted...

Before the fix:
![bad](https://github.com/Stability-AI/generative-models/assets/233837/0359f95e-f0ea-43e0-8a11-1d9dbbff1afd)

After the fix:
![good](https://github.com/Stability-AI/generative-models/assets/233837/eee69416-2b22-4ad4-8869-aebb0601ed64)