### PR TITLE
Initialize grid before attempting to rearrange

### DIFF
--- a/scripts/demo/streamlit_helpers.py
+++ b/scripts/demo/streamlit_helpers.py
@@ -775,7 +775,8 @@ def do_img2img(
 
                 if filter is not None:
                     samples = filter(samples)
-
+                
+                grid = torch.stack([samples])
                 grid = rearrange(grid, "n b c h w -> (n h) (b w) c")
                 outputs.image(grid.cpu().numpy())
                 if return_latents:


### PR DESCRIPTION
In img2img example grid variable is not initialized with samples and rearranging throws an error.  