### PR TITLE
Removed install triton when running on WIndows

### DIFF
--- a/requirements/pt2.txt
+++ b/requirements/pt2.txt
@@ -31,7 +31,7 @@ torchmetrics>=1.0.1
 torchvision>=0.15.2
 tqdm>=4.65.0
 transformers==4.19.1
-triton==2.0.0
+triton==2.0.0; platform_system != 'Windows'
 urllib3<1.27,>=1.25.4
 wandb>=0.15.6
 webdataset>=0.2.33


### PR DESCRIPTION
To make [step 3 here](https://stable-diffusion-art.com/stable-video-diffusion-img2vid/) obsolete, with this filter the Triton package will not be installed on Windows.