### PR TITLE
Fix SVD image input

### DIFF
--- a/scripts/sampling/simple_video_sample.py
+++ b/scripts/sampling/simple_video_sample.py
@@ -164,6 +164,8 @@ def sample(
             with Image.open(input_img_path) as image:
                 if image.mode == "RGBA":
                     input_image = image.convert("RGB")
+                else:
+                    input_image = image.copy()
                 w, h = image.size
 
                 if h % 64 != 0 or w % 64 != 0:


### PR DESCRIPTION
Found a bug of SVD after the SV3D update:

If the input is a RGB image for SVD, The variable 'input_image' will not be assigned and raises:
```
UnboundLocalError: local variable 'input_image' referenced before assignment
```
Using `copy()` rather than direct assignment, or the following error will raise since the file is closed by the 'with' context manager:
```
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'PngImageFile'
```
