### PR TITLE
Add low VRAM mode, CPU-only mode + image pre-loading fix

### DIFF
--- a/scripts/demo/video_sampling.py
+++ b/scripts/demo/video_sampling.py
@@ -180,6 +180,12 @@ if __name__ == "__main__":
 
         if mode == "img2vid":
             img = load_img_for_prediction(W, H)
+
+            # Check if the image is None and use a dummy image if necessary
+            if img is None:
+                st.warning("No image provided. Using a dummy tensor for initialization.")
+                img = torch.zeros([1, 3, H, W]).to(device)  # Dummy tensor
+
             if "sv3d" in version:
                 cond_aug = 1e-5
             else:


### PR DESCRIPTION
1. **Low VRAM mode implemented**: Introduced the unimplemented option lingering around in `streamlit_helpers.py` to run the model with half-precision (`float16`). Allows efficient usage on GPUs with limited memory, lowering memory requirements by half without significantly compromising output quality.

2. **CPU-only mode**: added an option to run the model on CPUs for users without the necessary CUDA GPU hardware, though at slower speeds.

Both can be set with True/False in `streamlit_helpers.py`, although a more viable solution in the future would be to i.e. add a separate `config.ini` w/ `configparser` for the entire framework.

3. **Image Loading Fix**: Fixed an issue where the app would throw an error if an image was not loaded before model execution. The model now uses a dummy tensor until the image is loaded in. See: `video_sampling.py`