### PR TITLE
Fix: UnboundLocalError on input_image variable assignment

### DIFF
--- a/scripts/sampling/simple_video_sample.py
+++ b/scripts/sampling/simple_video_sample.py
@@ -168,7 +168,10 @@ def sample(
 
                 if h % 64 != 0 or w % 64 != 0:
                     width, height = map(lambda x: x - x % 64, (w, h))
-                    input_image = input_image.resize((width, height))
+                    if image.mode == "RGBA":
+                        input_image = input_image.resize((width, height))
+                    else:
+                        input_image = image.resize((width, height))
                     print(
                         f"WARNING: Your image is of size {h}x{w} which is not divisible by 64. We are resizing to {height}x{width}!"
                     )


### PR DESCRIPTION
Fix: `UnboundLocalError` on input_image variable assignment
## Summary
This PR fixes an UnboundLocalError caused by referencing the input_image variable before it is properly assigned when the image size is not divisible by 64.

## Problem
When an image's dimensions (h or w) are not divisible by 64, the following block resizes the image. However, due to inconsistent handling of the input_image assignment, this error occurs:

`input_image = input_image.resize((width, height))  # UnboundLocalError`
This happens because input_image is referenced before being initialized in all cases, particularly when the image.mode != "RGBA".

##  Solution
Fixed the code by ensuring input_image is consistently assigned regardless of the image mode.
Corrected the logic to ensure input_image is initialized only once after the width and height adjustments.

```
if h % 64 != 0 or w % 64 != 0:
    width, height = map(lambda x: x - x % 64, (w, h))
    
    if image.mode == "RGBA":
        input_image = input_image.resize((width, height))
    else:
        input_image = image.resize((width, height))  # Fixed initialization
    
    print(f"WARNING: Your image is of size {h}x{w} which is not divisible by 64. Resizing to {height}x{width}!")

```
## Impact
This fix eliminates the `UnboundLocalError` by ensuring proper initialization of the input_image variable.
The logic for resizing non-divisible images is now handled correctly for both RGBA and non-RGBA image modes.
Testing
Verified that the code runs without errors on images with dimensions both divisible and non-divisible by 64.
Tested with images in both RGBA and other modes to ensure correct behavior in resizing.
